### PR TITLE
fix 'Log is not a function'

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function hash(value) {
   return (hash >>> 0).toString(36);
 }
 
-async function removeAppManifest(directory, log) {
+async function removeAppManifest(directory, appDir, log) {
   log("Removing App Manifest");
   const files = await glob(`**/${appDir}/manifest.json`, {
     cwd: directory,


### PR DESCRIPTION
#9 still didn't fix everything, there was a mistake in the removeAppManifest function signature, appDir wasn't being defined.

```
error during build:
TypeError: log is not a function
    at removeAppManifest
```

Was being thrown, this PR fixes it.