### PR TITLE
Add option that prevents file removal

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ interface AdapterOptions {
 	fallback?: string;
 	precompress?: boolean;
 	manifest?: string;
+	emptyOutDir?: boolean;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/index.js
+++ b/index.js
@@ -22,14 +22,17 @@ export default function ({
   assets = pages,
   fallback,
   precompress = false,
-  manifest = "manifest.json"
+  manifest = "manifest.json",
+  emptyOutDir = true
 } = {}) {
   return {
     name: "sveltekit-adapter-chrome-extension",
 
     async adapt(builder) {
-      builder.rimraf(assets);
-      builder.rimraf(pages);
+      if (emptyOutDir) {
+        builder.rimraf(assets);
+        builder.rimraf(pages);
+      }
 
       builder.writeClient(assets);
 


### PR DESCRIPTION
Hey,

first of all, thanks for creating this adapter. It's quite useful.

I had an issue using it in the 'watch mode', though. I have some other watch commands running as well. When a file change is detected and the adapter rebuilds the output, it first removes all files in the `build` directory. This, of course, also removes all other files generated by the other commands.

I added an option to disable that behavior if wanted. I named it like it is named in the vite build config `emptyOutDir`.