### PR TITLE
Fix prerender option name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Based on [@sveltekit/adapter-static](https://github.com/sveltejs/kit/blob/master/packages/adapter-static). Credit goes to [these people](https://github.com/sveltejs/kit/graphs/contributors) for their hard work to make Svelte so great
 
-> 🚧 If you are using SvelteKit v1.0.0+, make sure to set your `prerendered=true` for every page reference by your extension so SvelteKit generates the HTML files.
+> 🚧 If you are using SvelteKit v1.0.0+, make sure to set your `prerender=true` for every page reference by your extension so SvelteKit generates the HTML files.
 
 ## Usage
 


### PR DESCRIPTION
Most probably it's a typo because build script is failing if `prerendered` option is exported from a `+page.ts` file:
> Error: Invalid export 'prerendered' in / (valid exports are load, prerender, csr, ssr, trailingSlash, or anything with a '_' prefix)