### PR TITLE
fix: Bump @sveltejs/adapter-static peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {
-    "@sveltejs/adapter-static": "^2.0.1"
+    "@sveltejs/adapter-static": "^3.0.1"
   }
 }


### PR DESCRIPTION
Bumps the version of `@sveltejs/adapter-static` in `peerDependencies` to resolve #33