### PR TITLE
Strip script tabs and newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ async function removeInlineScripts(directory, log) {
         (a, c) => a + `${c}="${node.attribs[c]}" `,
         ""
       );
-      const innerScript = node.children[0].data;
+      const innerScript = node.children[0].data.replace(/[\t\n]/g, "");
       const fullTag = $("script").toString();
       //get new filename
       const hashedName = `script-${hash(innerScript)}.js`;


### PR DESCRIPTION
The formatting wasn't great before anyway and it reduces script sizes by around 10%.