### PR TITLE
Remove all inline scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,13 +84,11 @@ async function removeInlineScripts(directory, log) {
   const files = await glob("**/*.{html}", {
     cwd: directory,
     dot: true,
-    aboslute: true,
+    absolute: true,
     filesOnly: true,
   });
 
-  files
-    .map((f) => join(directory, f))
-    .forEach((file) => {
+  files.forEach((file) => {
       log.minor(`file: ${file}`);
       const f = readFileSync(file);
       const $ = load(f.toString());

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ import {
   readFileSync,
   statSync,
   unlinkSync,
-  writeFileSync
+  writeFileSync,
 } from "fs";
-import { join, dirname } from "path";
+import { dirname, join } from "path";
 import { pipeline } from "stream";
 import glob from "tiny-glob";
 import { promisify } from "util";
@@ -38,7 +38,7 @@ export default function(options) {
 
       // operation required since generated app manifest will overwrite the static extension manifest.json
       reWriteExtensionManifest(assets, manifest, builder);
-    }
+    },
   };
 }
 
@@ -65,7 +65,7 @@ async function removeAppManifest(directory, appDir, log) {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true
+    filesOnly: true,
   });
 
   files.forEach((path) => {
@@ -87,7 +87,7 @@ async function removeInlineScripts(directory, log) {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true
+    filesOnly: true,
   });
 
   for (const file of files) {
@@ -175,11 +175,13 @@ async function compress(directory) {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true
+    filesOnly: true,
   });
 
   await Promise.all(
-    files.map((file) => Promise.all([compress_file(file, "gz"), compress_file(file, "br")]))
+    files.map((file) =>
+      Promise.all([compress_file(file, "gz"), compress_file(file, "br")])
+    )
   );
 }
 
@@ -191,12 +193,13 @@ async function compress_file(file, format = "gz") {
   const compress =
     format == "br"
       ? zlib.createBrotliCompress({
-          params: {
-            [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
-            [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
-            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
-          }
-        })
+        params: {
+          [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+          [zlib.constants.BROTLI_PARAM_QUALITY]:
+            zlib.constants.BROTLI_MAX_QUALITY,
+          [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size,
+        },
+      })
       : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
 
   const source = createReadStream(file);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import staticAdapter from "@sveltejs/adapter-static"
-import { load } from "cheerio"
+import staticAdapter from "@sveltejs/adapter-static";
+import { load } from "cheerio";
 import {
   createReadStream,
   createWriteStream,
@@ -7,39 +7,39 @@ import {
   readFileSync,
   statSync,
   unlinkSync,
-  writeFileSync,
-} from "fs"
-import { join, dirname } from "path"
-import { pipeline } from "stream"
-import glob from "tiny-glob"
-import { promisify } from "util"
-import zlib from "zlib"
-import { mkdirSync } from "fs"
+  writeFileSync
+} from "fs";
+import { join, dirname } from "path";
+import { pipeline } from "stream";
+import glob from "tiny-glob";
+import { promisify } from "util";
+import zlib from "zlib";
+import { mkdirSync } from "fs";
 
-const pipe = promisify(pipeline)
+const pipe = promisify(pipeline);
 
 /** @type {import('.')} */
-export default function (options) {
+export default function(options) {
   return {
     name: "sveltekit-adapter-chrome-extension",
 
     async adapt(builder) {
-      staticAdapter(options).adapt(builder)
+      staticAdapter(options).adapt(builder);
 
       /* extension */
-      const pages = options?.pages ?? "build"
-      const assets = options?.assets ?? pages
-      const manifest = options?.manifest ?? "manifest.json"
+      const pages = options?.pages ?? "build";
+      const assets = options?.assets ?? pages;
+      const manifest = options?.manifest ?? "manifest.json";
 
-      await removeInlineScripts(assets, builder.log)
+      await removeInlineScripts(assets, builder.log);
 
-      await removeAppManifest(assets, builder.config.kit.appDir, builder.log)
-      await removeAppManifest(".", assets, builder.log)
+      await removeAppManifest(assets, builder.config.kit.appDir, builder.log);
+      await removeAppManifest(".", assets, builder.log);
 
       // operation required since generated app manifest will overwrite the static extension manifest.json
-      reWriteExtensionManifest(assets, manifest, builder)
-    },
-  }
+      reWriteExtensionManifest(assets, manifest, builder);
+    }
+  };
 }
 
 /**
@@ -47,123 +47,123 @@ export default function (options) {
  * @param {import('types/hooks').StrictBody} value
  */
 function hash(value) {
-  let hash = 5381
-  let i = value.length
+  let hash = 5381;
+  let i = value.length;
 
   if (typeof value === "string") {
-    while (i) hash = (hash * 33) ^ value.charCodeAt(--i)
+    while (i) hash = (hash * 33) ^ value.charCodeAt(--i);
   } else {
-    while (i) hash = (hash * 33) ^ value[--i]
+    while (i) hash = (hash * 33) ^ value[--i];
   }
 
-  return (hash >>> 0).toString(36)
+  return (hash >>> 0).toString(36);
 }
 
 async function removeAppManifest(directory, appDir, log) {
-  log("Removing App Manifest")
+  log("Removing App Manifest");
   const files = await glob(`**/${appDir}/*manifest*.json`, {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true,
-  })
+    filesOnly: true
+  });
 
   files.forEach((path) => {
     try {
-      unlinkSync(path)
-      log.success(`Removed app manifest file at path: ${path}`)
+      unlinkSync(path);
+      log.success(`Removed app manifest file at path: ${path}`);
     } catch (err) {
       log.warn(
-        `Error removing app manifest file at path: ${path}. You may have to delete it manually before submitting you extension.\nError: ${err}`,
-      )
+        `Error removing app manifest file at path: ${path}. You may have to delete it manually before submitting you extension.\nError: ${err}`
+      );
     }
-  })
+  });
 }
 
 async function removeInlineScripts(directory, log) {
-  log("Removing Inline Scripts")
+  log("Removing Inline Scripts");
 
   const files = await glob("**/*.{html}", {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true,
-  })
+    filesOnly: true
+  });
 
   for (const file of files) {
-    log.minor(`Processing file: ${file}`)
+    log.minor(`Processing file: ${file}`);
 
     // Ensure the file exists
     if (!existsSync(file)) {
-      log.warn(`Skipping missing file: ${file}`)
-      continue
+      log.warn(`Skipping missing file: ${file}`);
+      continue;
     }
 
-    const html = readFileSync(file, "utf-8")
-    const $ = load(html)
-    const scriptNodes = $("script").get()
+    const html = readFileSync(file, "utf-8");
+    const $ = load(html);
+    const scriptNodes = $("script").get();
 
-    if (scriptNodes.length === 0) continue
+    if (scriptNodes.length === 0) continue;
 
-    let modified = false
-    let scriptIndex = 0
+    let modified = false;
+    let scriptIndex = 0;
 
     for (const node of scriptNodes) {
       // Skip external scripts (those with src attribute)
-      if (node.attribs && "src" in node.attribs) continue
+      if (node.attribs && "src" in node.attribs) continue;
 
       const scriptContent =
         node.children && node.children[0] && node.children[0].data
           ? node.children[0].data.trim()
-          : ""
+          : "";
 
-      if (!scriptContent) continue
+      if (!scriptContent) continue;
 
       const attribs = Object.keys(node.attribs || {}).reduce(
         (a, c) => a + `${c}="${node.attribs[c]}" `,
-        "",
-      )
+        ""
+      );
 
-      const scriptHash = hash(scriptContent)
-      const scriptFilename = `script-${scriptIndex}-${scriptHash}.js`
-      const scriptPath = join(directory, scriptFilename)
+      const scriptHash = hash(scriptContent);
+      const scriptFilename = `script-${scriptIndex}-${scriptHash}.js`;
+      const scriptPath = join(directory, scriptFilename);
 
       // Make sure directory exists (avoid ENOENT)
-      mkdirSync(dirname(scriptPath), { recursive: true })
+      mkdirSync(dirname(scriptPath), { recursive: true });
 
       // Replace inline script with external file reference
-      $(node).replaceWith(`<script ${attribs}src="/${scriptFilename}"></script>`)
-      writeFileSync(scriptPath, scriptContent)
-      log.success(`Extracted inline script -> ${scriptPath}`)
+      $(node).replaceWith(`<script ${attribs}src="/${scriptFilename}"></script>`);
+      writeFileSync(scriptPath, scriptContent);
+      log.success(`Extracted inline script -> ${scriptPath}`);
 
-      modified = true
-      scriptIndex++
+      modified = true;
+      scriptIndex++;
     }
 
     if (modified) {
-      writeFileSync(file, $.html())
-      log.minor(`Rewrote HTML file: ${file}`)
+      writeFileSync(file, $.html());
+      log.minor(`Rewrote HTML file: ${file}`);
     }
   }
 }
 
 function reWriteExtensionManifest(directory, manifest, builder) {
-  const { log, getStaticDirectory, getClientDirectory, copy } = builder
-  log("Re-writing extension manifest")
-  let sourceFilePath
+  const { log, getStaticDirectory, getClientDirectory, copy } = builder;
+  log("Re-writing extension manifest");
+  let sourceFilePath;
   if (typeof getStaticDirectory !== "undefined") {
-    sourceFilePath = join(getStaticDirectory(), manifest)
+    sourceFilePath = join(getStaticDirectory(), manifest);
   } else {
-    sourceFilePath = join(getClientDirectory(), manifest)
+    sourceFilePath = join(getClientDirectory(), manifest);
   }
   if (existsSync(sourceFilePath)) {
-    log.info("Extension manifest found")
-    const res = copy(sourceFilePath, join(directory, "manifest.json"))
-    log.success("Successfully re-wrote extension manifest")
+    log.info("Extension manifest found");
+    const res = copy(sourceFilePath, join(directory, "manifest.json"));
+    log.success("Successfully re-wrote extension manifest");
   } else {
     log.error(
-      `Extension manifest not found. Make sure you've added your extension manifest in your statics directory with the name ${manifest}`,
-    )
+      `Extension manifest not found. Make sure you've added your extension manifest in your statics directory with the name ${manifest}`
+    );
   }
 }
 
@@ -175,12 +175,12 @@ async function compress(directory) {
     cwd: directory,
     dot: true,
     absolute: true,
-    filesOnly: true,
-  })
+    filesOnly: true
+  });
 
   await Promise.all(
-    files.map((file) => Promise.all([compress_file(file, "gz"), compress_file(file, "br")])),
-  )
+    files.map((file) => Promise.all([compress_file(file, "gz"), compress_file(file, "br")]))
+  );
 }
 
 /**
@@ -194,13 +194,13 @@ async function compress_file(file, format = "gz") {
           params: {
             [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
             [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
-            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size,
-          },
+            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
+          }
         })
-      : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION })
+      : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
 
-  const source = createReadStream(file)
-  const destination = createWriteStream(`${file}.${format}`)
+  const source = createReadStream(file);
+  const destination = createWriteStream(`${file}.${format}`);
 
-  await pipe(source, compress, destination)
+  await pipe(source, compress, destination);
 }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import {
   createReadStream,
   createWriteStream,
   existsSync,
+  mkdirSync,
   readFileSync,
   statSync,
   unlinkSync,
@@ -14,7 +15,6 @@ import { pipeline } from "stream";
 import glob from "tiny-glob";
 import { promisify } from "util";
 import zlib from "zlib";
-import { mkdirSync } from "fs";
 
 const pipe = promisify(pipeline);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import staticAdapter from "@sveltejs/adapter-static";
-import { load } from "cheerio";
+import staticAdapter from "@sveltejs/adapter-static"
+import { load } from "cheerio"
 import {
   createReadStream,
   createWriteStream,
@@ -8,37 +8,38 @@ import {
   statSync,
   unlinkSync,
   writeFileSync,
-} from "fs";
-import { dirname, join } from "path";
-import { pipeline } from "stream";
-import glob from "tiny-glob";
-import { promisify } from "util";
-import zlib from "zlib";
+} from "fs"
+import { join, dirname } from "path"
+import { pipeline } from "stream"
+import glob from "tiny-glob"
+import { promisify } from "util"
+import zlib from "zlib"
+import { mkdirSync } from "fs"
 
-const pipe = promisify(pipeline);
+const pipe = promisify(pipeline)
 
 /** @type {import('.')} */
-export default function(options) {
+export default function (options) {
   return {
     name: "sveltekit-adapter-chrome-extension",
 
     async adapt(builder) {
-      staticAdapter(options).adapt(builder);
+      staticAdapter(options).adapt(builder)
 
       /* extension */
-      const pages = options?.pages ?? "build";
-      const assets = options?.assets ?? pages;
-      const manifest = options?.manifest ?? "manifest.json";
+      const pages = options?.pages ?? "build"
+      const assets = options?.assets ?? pages
+      const manifest = options?.manifest ?? "manifest.json"
 
-      await removeInlineScripts(assets, builder.log);
+      await removeInlineScripts(assets, builder.log)
 
-      await removeAppManifest(assets, builder.config.kit.appDir, builder.log);
-      await removeAppManifest(".", assets, builder.log);
+      await removeAppManifest(assets, builder.config.kit.appDir, builder.log)
+      await removeAppManifest(".", assets, builder.log)
 
       // operation required since generated app manifest will overwrite the static extension manifest.json
-      reWriteExtensionManifest(assets, manifest, builder);
+      reWriteExtensionManifest(assets, manifest, builder)
     },
-  };
+  }
 }
 
 /**
@@ -46,95 +47,124 @@ export default function(options) {
  * @param {import('types/hooks').StrictBody} value
  */
 function hash(value) {
-  let hash = 5381;
-  let i = value.length;
+  let hash = 5381
+  let i = value.length
 
   if (typeof value === "string") {
-    while (i) hash = (hash * 33) ^ value.charCodeAt(--i);
+    while (i) hash = (hash * 33) ^ value.charCodeAt(--i)
   } else {
-    while (i) hash = (hash * 33) ^ value[--i];
+    while (i) hash = (hash * 33) ^ value[--i]
   }
 
-  return (hash >>> 0).toString(36);
+  return (hash >>> 0).toString(36)
 }
 
 async function removeAppManifest(directory, appDir, log) {
-  log("Removing App Manifest");
+  log("Removing App Manifest")
   const files = await glob(`**/${appDir}/*manifest*.json`, {
     cwd: directory,
     dot: true,
     absolute: true,
     filesOnly: true,
-  });
+  })
 
   files.forEach((path) => {
     try {
-      unlinkSync(path);
-      log.success(`Removed app manifest file at path: ${path}`);
+      unlinkSync(path)
+      log.success(`Removed app manifest file at path: ${path}`)
     } catch (err) {
       log.warn(
-        `Error removing app manifest file at path: ${path}. You may have to delete it manually before submitting you extension.\nError: ${err}`
-      );
+        `Error removing app manifest file at path: ${path}. You may have to delete it manually before submitting you extension.\nError: ${err}`,
+      )
     }
-  });
+  })
 }
 
 async function removeInlineScripts(directory, log) {
-  log("Removing Inline Scripts");
+  log("Removing Inline Scripts")
+
   const files = await glob("**/*.{html}", {
     cwd: directory,
     dot: true,
     absolute: true,
+    absolute: true,
     filesOnly: true,
-  });
+  })
 
-  files.forEach((file) => {
-      log.minor(`file: ${file}`);
-      const f = readFileSync(file);
-      const $ = load(f.toString());
-      const node = $("script").get()[0];
+  for (const file of files) {
+    log.minor(`Processing file: ${file}`)
 
-      if (!node) return;
-      if (Object.keys(node.attribs).includes("src")) return; // if there is a src, it's not an inline script
+    // Ensure the file exists
+    if (!existsSync(file)) {
+      log.warn(`Skipping missing file: ${file}`)
+      continue
+    }
 
-      const attribs = Object.keys(node.attribs).reduce(
+    const html = readFileSync(file, "utf-8")
+    const $ = load(html)
+    const scriptNodes = $("script").get()
+
+    if (scriptNodes.length === 0) continue
+
+    let modified = false
+    let scriptIndex = 0
+
+    for (const node of scriptNodes) {
+      // Skip external scripts (those with src attribute)
+      if (node.attribs && "src" in node.attribs) continue
+
+      const scriptContent =
+        node.children && node.children[0] && node.children[0].data
+          ? node.children[0].data.trim()
+          : ""
+
+      if (!scriptContent) continue
+
+      const attribs = Object.keys(node.attribs || {}).reduce(
         (a, c) => a + `${c}="${node.attribs[c]}" `,
-        ""
-      );
-      const innerScript = node.children[0].data;
-      const fullTag = $("script").toString();
-      //get new filename
-      const hashedName = `script-${hash(innerScript)}.js`;
-      //remove from orig html file and replace with new script tag
-      const newHtml = f
-        .toString()
-        .replace(fullTag, `<script ${attribs} src="${hashedName}"></script>`);
-      writeFileSync(file, newHtml);
-      log.minor(`Rewrote ${file}`);
+        "",
+      )
 
-      const p = `${dirname(file)}/${hashedName}`;
-      writeFileSync(p, innerScript);
-      log.success(`Inline script extracted and saved at: ${p}`);
-    });
+      const scriptHash = hash(scriptContent)
+      const scriptFilename = `script-${scriptIndex}-${scriptHash}.js`
+      const scriptPath = join(directory, scriptFilename)
+
+      // Make sure directory exists (avoid ENOENT)
+      mkdirSync(dirname(scriptPath), { recursive: true })
+
+      // Replace inline script with external file reference
+      $(node).replaceWith(`<script ${attribs}src="/${scriptFilename}"></script>`)
+      writeFileSync(scriptPath, scriptContent)
+      log.success(`Extracted inline script -> ${scriptPath}`)
+
+      modified = true
+      scriptIndex++
+    }
+
+    if (modified) {
+      writeFileSync(file, $.html())
+      log.minor(`Rewrote HTML file: ${file}`)
+    }
+  }
 }
 
 function reWriteExtensionManifest(directory, manifest, builder) {
-  const { log, getStaticDirectory, getClientDirectory, copy } = builder;
-  log("Re-writing extension manifest");
-  let sourceFilePath;
+  const { log, getStaticDirectory, getClientDirectory, copy } = builder
+  log("Re-writing extension manifest")
+  let sourceFilePath
   if (typeof getStaticDirectory !== "undefined") {
-    sourceFilePath = join(getStaticDirectory(), manifest);
+    sourceFilePath = join(getStaticDirectory(), manifest)
   } else {
-    sourceFilePath = join(getClientDirectory(), manifest);
+    sourceFilePath = join(getClientDirectory(), manifest)
   }
   if (existsSync(sourceFilePath)) {
-    log.info("Extension manifest found");
-    const res = copy(sourceFilePath, join(directory, "manifest.json"));
-    log.success("Successfully re-wrote extension manifest");
+    log.info("Extension manifest found")
+    const res = copy(sourceFilePath, join(directory, "manifest.json"))
+    log.success("Successfully re-wrote extension manifest")
   } else {
     log.error(
-      `Extension manifest not found. Make sure you've added your extension manifest in your statics directory with the name ${manifest}`
-    );
+      `Extension manifest not found. Make sure you've added your extension manifest in your statics directory with the name ${manifest}`,
+    )
   }
 }
 
@@ -147,13 +177,11 @@ async function compress(directory) {
     dot: true,
     absolute: true,
     filesOnly: true,
-  });
+  })
 
   await Promise.all(
-    files.map((file) =>
-      Promise.all([compress_file(file, "gz"), compress_file(file, "br")])
-    )
-  );
+    files.map((file) => Promise.all([compress_file(file, "gz"), compress_file(file, "br")])),
+  )
 }
 
 /**
@@ -164,17 +192,16 @@ async function compress_file(file, format = "gz") {
   const compress =
     format == "br"
       ? zlib.createBrotliCompress({
-        params: {
-          [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
-          [zlib.constants.BROTLI_PARAM_QUALITY]:
-            zlib.constants.BROTLI_MAX_QUALITY,
-          [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size,
-        },
-      })
-      : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
+          params: {
+            [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+            [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size,
+          },
+        })
+      : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION })
 
-  const source = createReadStream(file);
-  const destination = createWriteStream(`${file}.${format}`);
+  const source = createReadStream(file)
+  const destination = createWriteStream(`${file}.${format}`)
 
-  await pipe(source, compress, destination);
+  await pipe(source, compress, destination)
 }

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { dirname, join } from "path";
+import { join, dirname } from "path";
 import { pipeline } from "stream";
 import glob from "tiny-glob";
 import { promisify } from "util";
 import zlib from "zlib";
+import { mkdirSync } from "fs";
 
 const pipe = promisify(pipeline);
 
@@ -81,43 +82,69 @@ async function removeAppManifest(directory, appDir, log) {
 
 async function removeInlineScripts(directory, log) {
   log("Removing Inline Scripts");
+
   const files = await glob("**/*.{html}", {
     cwd: directory,
     dot: true,
-    aboslute: true,
+    absolute: true,
     filesOnly: true,
   });
 
-  files
-    .map((f) => join(directory, f))
-    .forEach((file) => {
-      log.minor(`file: ${file}`);
-      const f = readFileSync(file);
-      const $ = load(f.toString());
-      const node = $("script").get()[0];
+  for (const file of files) {
+    log.minor(`Processing file: ${file}`);
 
-      if (!node) return;
-      if (Object.keys(node.attribs).includes("src")) return; // if there is a src, it's not an inline script
+    // Ensure the file exists
+    if (!existsSync(file)) {
+      log.warn(`Skipping missing file: ${file}`);
+      continue;
+    }
 
-      const attribs = Object.keys(node.attribs).reduce(
+    const html = readFileSync(file, "utf-8");
+    const $ = load(html);
+    const scriptNodes = $("script").get();
+
+    if (scriptNodes.length === 0) continue;
+
+    let modified = false;
+    let scriptIndex = 0;
+
+    for (const node of scriptNodes) {
+      // Skip external scripts (those with src attribute)
+      if (node.attribs && "src" in node.attribs) continue;
+
+      const scriptContent =
+        node.children && node.children[0] && node.children[0].data
+          ? node.children[0].data.trim()
+          : "";
+
+      if (!scriptContent) continue;
+
+      const attribs = Object.keys(node.attribs || {}).reduce(
         (a, c) => a + `${c}="${node.attribs[c]}" `,
         ""
       );
-      const innerScript = node.children[0].data;
-      const fullTag = $("script").toString();
-      //get new filename
-      const hashedName = `script-${hash(innerScript)}.js`;
-      //remove from orig html file and replace with new script tag
-      const newHtml = f
-        .toString()
-        .replace(fullTag, `<script ${attribs} src="${hashedName}"></script>`);
-      writeFileSync(file, newHtml);
-      log.minor(`Rewrote ${file}`);
 
-      const p = `${dirname(file)}/${hashedName}`;
-      writeFileSync(p, innerScript);
-      log.success(`Inline script extracted and saved at: ${p}`);
-    });
+      const scriptHash = hash(scriptContent);
+      const scriptFilename = `script-${scriptIndex}-${scriptHash}.js`;
+      const scriptPath = join(directory, scriptFilename);
+
+      // Make sure directory exists (avoid ENOENT)
+      mkdirSync(dirname(scriptPath), { recursive: true });
+
+      // Replace inline script with external file reference
+      $(node).replaceWith(`<script ${attribs}src="/${scriptFilename}"></script>`);
+      writeFileSync(scriptPath, scriptContent);
+      log.success(`Extracted inline script -> ${scriptPath}`);
+
+      modified = true;
+      scriptIndex++;
+    }
+
+    if (modified) {
+      writeFileSync(file, $.html());
+      log.minor(`Rewrote HTML file: ${file}`);
+    }
+  }
 }
 
 function reWriteExtensionManifest(directory, manifest, builder) {


### PR DESCRIPTION
I modified the removeInlineScripts function to work with multiple inline scripts.

I found that it only removed/extracted the script if there was only one script. If there were more than one script, it would not work.

My use case was the inline script that [mode-watcher](https://github.com/svecosystem/mode-watcher) creates.